### PR TITLE
fix: Restore broken link in CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 # Contributing to Vanguard
 
-To read more about how you can contribute to Vanguard, please read the [development guide](https://docs.vanguardbackup.com/development) on our docs site for the latest information.
+To read more about how you can contribute to Vanguard, please read the [development guide](https://docs.vanguardbackup.com/development-handbook) on our docs site for the latest information.


### PR DESCRIPTION
# Vanguard PR

## Description

Link in CONTRIBUTING.md to Vanguard Development Guide is broken and returns 404 response. I fixed the link.

Fixes # (issue) if applicable.

## Type of change

Please delete options that are not relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

- [ ] Automated testing (Feature tests, Unit tests)
- [ ] Manual testing (explain the steps)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes do not introduce any new warnings or errors
- [ ] New and existing tests pass locally with my changes

## Screenshots (if applicable):

## Additional context

Add any other context or screenshots about the pull request here.
