### PR TITLE
feat: Pinned Backup Tasks

### DIFF
--- a/app/Livewire/BackupTasks/Buttons/ToggleFavouriteButton.php
+++ b/app/Livewire/BackupTasks/Buttons/ToggleFavouriteButton.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\BackupTasks\Buttons;
+
+use App\Models\BackupTask;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use DanHarrin\LivewireRateLimiting\WithRateLimiting;
+use Illuminate\View\View;
+use Livewire\Component;
+use Masmerise\Toaster\Toaster;
+
+/**
+ * Manages the button for toggling the favourite state of a backup task.
+ *
+ * This component handles the UI and logic for favouring and unfavouring a backup task,
+ * including rate limiting to prevent abuse.
+ */
+class ToggleFavouriteButton extends Component
+{
+    use WithRateLimiting;
+
+    /** @var BackupTask The backup task to be toggled */
+    public BackupTask $backupTask;
+
+    /**
+     * Refresh the component.
+     *
+     * Dispatches a refresh event to update the component's state.
+     */
+    public function refreshSelf(): void
+    {
+        $this->dispatch('$refresh');
+    }
+
+    /**
+     * Toggle the favourite state of the backup task.
+     *
+     * Attempts to toggle the task's state while respecting rate limits.
+     * Notifies the user of the action's result.
+     */
+    public function toggleFavouriteState(): void
+    {
+        try {
+            $this->ensureNotRateLimited();
+            $this->executeStateToggle();
+        } catch (TooManyRequestsException) {
+            $this->notifyRateLimitReached();
+        }
+    }
+
+    /**
+     * Render the toggle favourite button component.
+     *
+     * @return View The component's view
+     */
+    public function render(): View
+    {
+        return view('livewire.backup-tasks.buttons.toggle-favourite-button');
+    }
+
+    /**
+     * Get the event listeners for the component.
+     *
+     * @return array<string, string> The event listeners
+     */
+    protected function getListeners(): array
+    {
+        $taskId = $this->backupTask->getAttribute('id');
+
+        return [
+            "task-button-clicked-{$taskId}" => 'refreshSelf',
+            "echo-private:backup-tasks.{$taskId},BackupTaskStatusChanged" => 'refreshSelf',
+            'backup-task-status-changed' => 'refreshSelf',
+            'refresh-backup-tasks-table' => 'refreshSelf',
+        ];
+    }
+
+    /**
+     * Ensure the action is not rate limited.
+     *
+     * @throws TooManyRequestsException When rate limit is exceeded
+     */
+    private function ensureNotRateLimited(): void
+    {
+        $this->rateLimit(10);
+    }
+
+    /**
+     * Execute the state toggle action.
+     *
+     * Determines the current state and calls the appropriate method to change it.
+     * Dispatches events after the state change.
+     */
+    private function executeStateToggle(): void
+    {
+        $toggleAction = $this->backupTask->isFavourited()
+            ? [$this, 'unfavouriteBackupTask']
+            : [$this, 'favouriteBackupTask'];
+
+        $toggleAction();
+
+        $this->dispatch('toggle-favourite-button-clicked-' . $this->backupTask->getAttribute('id'));
+        $this->dispatch('refresh-backup-tasks-table');
+        $this->dispatch('refreshBackupTasksTable');
+    }
+
+    /**
+     * Favourite the backup task.
+     *
+     * Changes the task's state to resumed and notifies the user.
+     */
+    private function favouriteBackupTask(): void
+    {
+        $this->backupTask->favourite();
+        Toaster::success('Backup task has been pinned.');
+    }
+
+    /**
+     * Unfavourite the backup task.
+     *
+     * Changes the task's state to paused and notifies the user.
+     */
+    private function unfavouriteBackupTask(): void
+    {
+        $this->backupTask->unfavourite();
+        Toaster::success('Backup task has been unpinned.');
+    }
+
+    /**
+     * Notify the user that the rate limit has been reached.
+     *
+     * Displays an error message to the user.
+     */
+    private function notifyRateLimitReached(): void
+    {
+        Toaster::error('You are doing this too often.');
+    }
+}

--- a/app/Livewire/BackupTasks/Tables/IndexItem.php
+++ b/app/Livewire/BackupTasks/Tables/IndexItem.php
@@ -104,6 +104,7 @@ class IndexItem extends Component
             sprintf('echo-private:backup-tasks.%s,BackupTaskStatusChanged', $this->backupTask->getAttribute('id')) => 'echoBackupTaskStatusReceivedEvent',
             'task-button-clicked-' . $this->backupTask->getAttribute('id') => '$refresh',
             'toggle-pause-button-clicked-' . $this->backupTask->getAttribute('id') => '$refresh',
+            'toggle-favourite-button-clicked-' . $this->backupTask->getAttribute('id') => '$refresh',
             'log-modal-updated-' . $this->backupTask->getAttribute('id') => '$refresh',
             'backup-task-status-changed' => '$refresh',
         ];

--- a/app/Livewire/BackupTasks/Tables/IndexTable.php
+++ b/app/Livewire/BackupTasks/Tables/IndexTable.php
@@ -102,7 +102,9 @@ class IndexTable extends Component
             $query->where('label', 'like', "%{$this->search}%");
         }
 
-        return $query->latest('id');
+        return $query->orderByRaw('favourited_at IS NULL')
+            ->orderBy('favourited_at', 'desc')
+            ->latest('id');
     }
 
     /**

--- a/app/Models/BackupTask.php
+++ b/app/Models/BackupTask.php
@@ -601,6 +601,32 @@ class BackupTask extends Model
     }
 
     /**
+     * Check if the task is favourited.
+     */
+    public function isFavourited(): bool
+    {
+        return ! is_null($this->favourited_at);
+    }
+
+    /**
+     * Favour the backup task.
+     */
+    public function favourite(): void
+    {
+        $this->update(['favourited_at' => now()]);
+        $this->save();
+    }
+
+    /**
+     * Unfavour the backup task.
+     */
+    public function unfavourite(): void
+    {
+        $this->update(['favourited_at' => null]);
+        $this->save();
+    }
+
+    /**
      * Check if the task has a file name appended.
      */
     public function hasFileNameAppended(): bool

--- a/database/factories/BackupTaskFactory.php
+++ b/database/factories/BackupTaskFactory.php
@@ -34,4 +34,13 @@ class BackupTaskFactory extends Factory
             ];
         });
     }
+
+    public function favourited(): self
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'favourited_at' => now(),
+            ];
+        });
+    }
 }

--- a/database/migrations/2024_12_29_152006_add_favourited_at_to_backup_tasks_table.php
+++ b/database/migrations/2024_12_29_152006_add_favourited_at_to_backup_tasks_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('backup_tasks', function (Blueprint $table) {
+            $table->dateTime('favourited_at')->nullable()->after('created_at');
+        });
+    }
+};

--- a/lang/da.json
+++ b/lang/da.json
@@ -895,5 +895,11 @@
     "Need Help?": "Brug for hjælp?",
     "If you need assistance understanding any part of this dashboard or have questions about your Vanguard instance, please don't hesitate to": "Hvis du har brug for hjælp til at forstå nogen del af dette dashboard eller har spørgsmål om din Vanguard-forekomst, skal du ikke tøve med at",
     "contact us": "kontakte os",
-    "This dashboard provides a comprehensive overview of your Vanguard instance. It displays crucial information about your system and application details.": "Dette dashboard giver et omfattende overblik over din Vanguard-instans. Det viser vigtige oplysninger om dit system og applikationsdetaljer."
+    "This dashboard provides a comprehensive overview of your Vanguard instance. It displays crucial information about your system and application details.": "Dette dashboard giver et omfattende overblik over din Vanguard-instans. Det viser vigtige oplysninger om dit system og applikationsdetaljer.",
+    "Click to unpin this task": "Klik for at fjerne sikkerhedskopieringsopgaven fra fastgørelse",
+    "Task Unpinned": "Sikkerhedskopieringsopgave ikke længere fastgjort",
+    "Click to pin this task": "Klik for at fastgøre sikkerhedskopieringsopgaven",
+    "Task Pinned": "Sikkerhedskopieringsopgave fastgjort",
+    "Backup task has been pinned.": "Sikkerhedskopieringsopgaven er blevet fastgjort.",
+    "Backup task has been unpinned.": "Sikkerhedskopieringsopgaven er blevet fjernet fra fastgørelse."
 }

--- a/resources/views/livewire/backup-tasks/buttons/toggle-favourite-button.blade.php
+++ b/resources/views/livewire/backup-tasks/buttons/toggle-favourite-button.blade.php
@@ -1,0 +1,23 @@
+<div>
+    @if ($backupTask->isFavourited())
+        <x-primary-button
+            wire:click="toggleFavouriteState"
+            type="button"
+            class="bg-amber-50 !p-2"
+            title="{{ __('Click to unpin this task') }}"
+        >
+            <span class="sr-only">{{ __('Task Unpinned') }}</span>
+            @svg('hugeicons-pin-off', 'h-4 w-4')
+        </x-primary-button>
+    @else
+        <x-secondary-button
+            wire:click="toggleFavouriteState"
+            type="button"
+            class="!p-2"
+            title="{{ __('Click to pin this task') }}"
+        >
+            <span class="sr-only">{{ __('Task Pinned') }}</span>
+            @svg('hugeicons-pin', 'h-4 w-4')
+        </x-secondary-button>
+    @endif
+</div>

--- a/resources/views/livewire/backup-tasks/tables/index-item.blade.php
+++ b/resources/views/livewire/backup-tasks/tables/index-item.blade.php
@@ -150,6 +150,11 @@
                     :wire:key="'toggle-pause-button-' . $backupTask->id"
                 />
 
+                <livewire:backup-tasks.buttons.toggle-favourite-button
+                    :backupTask="$backupTask"
+                    :wire:key="'toggle-favourite-button-' . $backupTask->id"
+                />
+
                 <a href="{{ route('backup-tasks.edit', $backupTask) }}" wire:navigate>
                     <x-secondary-button class="!p-2">
                         <span class="sr-only">
@@ -297,6 +302,11 @@
                 <livewire:backup-tasks.buttons.toggle-pause-button
                     :backupTask="$backupTask"
                     :wire:key="'toggle-pause-button-large-' . $backupTask->id"
+                />
+
+                <livewire:backup-tasks.buttons.toggle-favourite-button
+                    :backupTask="$backupTask"
+                    :wire:key="'toggle-favourite-button-large-' . $backupTask->id"
                 />
 
                 <a href="{{ route('backup-tasks.edit', $backupTask) }}" wire:navigate>

--- a/tests/Unit/Models/BackupTaskTest.php
+++ b/tests/Unit/Models/BackupTaskTest.php
@@ -562,6 +562,18 @@ it('returns false if the backup task is not paused', function (): void {
     expect($task->isPaused())->toBeFalse();
 });
 
+it('returns true if the backup task is favourited', function (): void {
+    $task = BackupTask::factory()->favourited()->create();
+
+    expect($task->isFavourited())->toBeTrue();
+});
+
+it('returns false if the backup task is not favourited', function (): void {
+    $task = BackupTask::factory()->create();
+
+    expect($task->isFavourited())->toBeFalse();
+});
+
 it('pauses the backup task', function (): void {
     $task = BackupTask::factory()->create();
 
@@ -576,6 +588,22 @@ it('unpauses the backup task', function (): void {
     $task->resume();
 
     expect($task->isPaused())->toBeFalse();
+});
+
+it('favourites the backup task', function (): void {
+    $task = BackupTask::factory()->create();
+
+    $task->favourite();
+
+    expect($task->isFavourited())->toBeTrue();
+});
+
+it('unfavourites the backup task', function (): void {
+    $task = BackupTask::factory()->paused()->create();
+
+    $task->unfavourite();
+
+    expect($task->isFavourited())->toBeFalse();
 });
 
 it('scopes all the unpaused backup tasks', function (): void {


### PR DESCRIPTION
# Pull Request

## Description

This PR introduces a 'pin' functionality to the Backup Tasks system. With this, users are able to pin their preferred Tasks to the top of the list.

This is a WIP as we need to address the button formatting. The core functionality is complete however.


## Type of change

Please delete options that are not relevant to this PR.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Automated testing (Feature tests, Unit tests)
- [x] Manual testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce any new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have used translation helpers and provided translations (where appropriate)

## Screenshots (if applicable):

![CleanShot 2024-12-29 at 16 28 56](https://github.com/user-attachments/assets/3f420fb3-d6a4-4dab-9ade-336497f5ad55)

