### PR TITLE
Fix: Deprecated: explode(): Passing null to parameter #2 ($string) 

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -40,5 +40,5 @@ return [
 
     'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
 
-    'admin_email_addresses' => explode(',', env('ADMIN_EMAIL_ADDRESSES')),
+    'admin_email_addresses' => explode(',', env('ADMIN_EMAIL_ADDRESSES', '')),
 ];

--- a/lang/da.json
+++ b/lang/da.json
@@ -901,5 +901,7 @@
     "Click to pin this task": "Klik for at fastgøre sikkerhedskopieringsopgaven",
     "Task Pinned": "Sikkerhedskopieringsopgave fastgjort",
     "Backup task has been pinned.": "Sikkerhedskopieringsopgaven er blevet fastgjort.",
-    "Backup task has been unpinned.": "Sikkerhedskopieringsopgaven er blevet fjernet fra fastgørelse."
+    "Backup task has been unpinned.": "Sikkerhedskopieringsopgaven er blevet fjernet fra fastgørelse.",
+    "Security Notice": "Sikkerhedsmeddelelse",
+    "All keys entered here are encrypted and securely stored in the database.": "Alle nøgler indtastet her er krypteret og sikkert gemt i databasen."
 }

--- a/resources/views/livewire/backup-destinations/create-backup-destination-form.blade.php
+++ b/resources/views/livewire/backup-destinations/create-backup-destination-form.blade.php
@@ -15,6 +15,12 @@
                     title="{{ __('About Local Configuration') }}"
                     text="{{ __('You will specify a local path when creating a Backup Task.') }}"
                 />
+            @else
+                <x-notice
+                    type="info"
+                    title="{{ __('Security Notice') }}"
+                    text="{{ __('All keys entered here are encrypted and securely stored in the database.') }}"
+                />
             @endif
 
             <div class="mt-4 flex flex-col space-y-4 md:flex-row md:space-x-6 md:space-y-0">


### PR DESCRIPTION
# Pull Request

## Description

There was a bug that showed itself when the `.ENV` didn't have any admin email addresses set. 

Per PHP 8.4 `Passing null to parameter #2 ($string) of type string is deprecated` which this PR aims to address.

## Type of change

Please delete options that are not relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
## How Has This Been Tested?

- [ ] Automated testing (Feature tests, Unit tests)
- [x] Manual testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce any new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have used translation helpers and provided translations (where appropriate)

## Screenshots (if applicable):

## Additional context

Add any other context or screenshots about the pull request here. Can remove this section if not necessary. 
