### PR TITLE
fix: Resolve argument error for sanctum command

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -29,7 +29,7 @@ Schedule::command(SendSummaryBackupTaskEmails::class)
 Schedule::command(FetchNewFeatures::class)
     ->dailyAt('02:00');
 
-Schedule::command(PruneExpired::class, ['hours' => 24])
+Schedule::command(PruneExpired::class)
     ->dailyAt('05:00');
 
 Schedule::command(SendPersonalAccessTokenExpiringSoon::class)


### PR DESCRIPTION
# Pull Request

## Description

On production we'd receive an error when the sanctum prune expired API token command would run daily, this is due to a parameter being set that isn't necessary.

**Log:**
```
Symfony\Component\Console\Exception\RuntimeException 
/vendor/symfony/console/Input/ArgvInput.php in Symfony\Component\Console\Input\ArgvInput::parseArgument
No arguments expected for "sanctum:prune-expired" command, got "hours=24".
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Automated testing (Feature tests, Unit tests)
- [x] Manual testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce any new warnings or errors
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have used translation helpers and provided translations (where appropriate)