### PR TITLE
fix: improve our 404 response for webhooks

### DIFF
--- a/tests/Feature/BackupTasks/Webhooks/BackupTaskWebhookTest.php
+++ b/tests/Feature/BackupTasks/Webhooks/BackupTaskWebhookTest.php
@@ -121,3 +121,11 @@ it('handles rate limiting', function (): void {
     $response->assertStatus(429)
         ->assertJson(['message' => 'Too many requests. Please try again later.']);
 });
+
+it('handles a non-existent backup task correctly', function () {
+
+    $response = $this->postJson(route('webhooks.backup-tasks.run', ['backupTask' => '123456789']));
+
+    $response->assertStatus(404)
+        ->assertJson(['message' => 'Record not found.']);
+});


### PR DESCRIPTION
# Pull Request

## Description

Previously, if a webhook Backup Task was not found, we'd get the response:

```
"message": "No query results for model [App\\Models\\BackupTask] 123456789"
```

However, this PR changes this to:

```
"message":"Record not found."
```

Much better I think!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Automated testing (Feature tests, Unit tests)
- [x] Manual testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce any new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have used translation helpers and provided translations (where appropriate)

