### PR TITLE
style: Resolved overlapping buttons on backup tasks view

### DIFF
--- a/resources/views/livewire/backup-tasks/tables/index-item.blade.php
+++ b/resources/views/livewire/backup-tasks/tables/index-item.blade.php
@@ -1,30 +1,22 @@
-<div class="mb-4 overflow-hidden rounded-none bg-transparent transition-all duration-300">
-    <div class="space-y-4 p-3">
-        <!-- Responsive View (Collapsible) -->
+<div class="mb-4 rounded-lg bg-white shadow-sm transition-all duration-300 dark:bg-gray-800">
+    <div class="space-y-4 p-4">
+        <!-- Mobile View (Collapsible) -->
         <div class="md:hidden">
-            <!-- Task Type, Label, and Status - Always visible -->
+            <!-- Task Type, Label, and Status -->
             <div class="flex items-center justify-between">
                 <div class="flex items-center space-x-3">
                     <div class="flex-shrink-0">
                         @if ($backupTask->isFilesType())
                             <div class="group relative" title="{{ __('Files Task') }}">
-                                <div
-                                    class="absolute inset-0 rotate-3 transform rounded-lg bg-gradient-to-br from-purple-300 to-purple-400 transition-all duration-300 group-hover:rotate-6 group-hover:scale-105 dark:from-purple-600 dark:to-purple-700"
-                                ></div>
-                                <div
-                                    class="relative rounded-lg bg-white p-2 shadow-sm transition-all duration-300 group-hover:shadow-md dark:bg-gray-800"
-                                >
+                                <div class="absolute inset-0 rotate-3 transform rounded-lg bg-gradient-to-br from-purple-300 to-purple-400 transition-all duration-300 group-hover:rotate-6 group-hover:scale-105 dark:from-purple-600 dark:to-purple-700"></div>
+                                <div class="relative rounded-lg bg-white p-2 shadow-sm transition-all duration-300 group-hover:shadow-md dark:bg-gray-800">
                                     @svg('hugeicons-file-01', 'h-5 w-5 text-purple-600 dark:text-purple-400')
                                 </div>
                             </div>
                         @elseif ($backupTask->isDatabaseType())
                             <div class="group relative" title="{{ __('Database Task') }}">
-                                <div
-                                    class="absolute inset-0 rotate-3 transform rounded-lg bg-gradient-to-br from-cyan-300 to-cyan-400 transition-all duration-300 group-hover:rotate-6 group-hover:scale-105 dark:from-cyan-600 dark:to-cyan-700"
-                                ></div>
-                                <div
-                                    class="relative rounded-lg bg-white p-2 shadow-sm transition-all duration-300 group-hover:shadow-md dark:bg-gray-800"
-                                >
+                                <div class="absolute inset-0 rotate-3 transform rounded-lg bg-gradient-to-br from-cyan-300 to-cyan-400 transition-all duration-300 group-hover:rotate-6 group-hover:scale-105 dark:from-cyan-600 dark:to-cyan-700"></div>
+                                <div class="relative rounded-lg bg-white p-2 shadow-sm transition-all duration-300 group-hover:shadow-md dark:bg-gray-800">
                                     @svg('hugeicons-database', 'h-5 w-5 text-cyan-600 dark:text-cyan-400')
                                 </div>
                             </div>
@@ -36,22 +28,14 @@
                         </h3>
                         <div class="flex space-x-2">
                             @if ($backupTask->tags()->exists())
-                                <button
-                                    x-data=""
-                                    x-on:click.prevent="$dispatch('open-modal', 'view-tags-{{ $backupTask->id }}')"
-                                    class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                                >
+                                <button x-data="" x-on:click.prevent="$dispatch('open-modal', 'view-tags-{{ $backupTask->id }}')" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
                                     @svg('hugeicons-tags', 'mr-1 h-3 w-3 text-gray-500 dark:text-gray-400')
                                     {{ $backupTask->tags->count() }}
                                 </button>
                             @endif
 
                             @if ($backupTask->notificationStreams()->exists())
-                                <button
-                                    x-data=""
-                                    x-on:click.prevent="$dispatch('open-modal', 'view-notification-streams-{{ $backupTask->id }}')"
-                                    class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                                >
+                                <button x-data="" x-on:click.prevent="$dispatch('open-modal', 'view-notification-streams-{{ $backupTask->id }}')" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
                                     @svg('hugeicons-notification-02', 'mr-1 h-3 w-3 text-gray-500 dark:text-gray-400')
                                     {{ $backupTask->notificationStreams->count() }}
                                 </button>
@@ -61,16 +45,12 @@
                 </div>
                 <div class="text-sm font-medium">
                     @if ($backupTask->isPaused())
-                        <span
-                            class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-800 dark:text-red-100"
-                        >
+                        <span class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-800 dark:text-red-100">
                             @svg('hugeicons-pause', 'mr-1 h-3.5 w-3.5')
                             {{ __('Paused') }}
                         </span>
                     @else
-                        <span
-                            class="{{ $backupTask->status === 'ready' ? 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100' : 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100' }} inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
-                        >
+                        <span class="{{ $backupTask->status === 'ready' ? 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100' : 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100' }} inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium">
                             @if ($backupTask->status === 'ready')
                                 @svg('hugeicons-checkmark-circle-02', 'mr-1 h-3.5 w-3.5')
                             @else
@@ -82,12 +62,9 @@
                 </div>
             </div>
 
-            <!-- Server, Destination, and Schedule - Collapsible Responsively -->
+            <!-- Server, Destination, and Schedule - Collapsible -->
             <div x-data="{ open: false }" class="my-3">
-                <button
-                    @click="open = !open"
-                    class="text-sm text-gray-600 hover:text-gray-900 focus:outline-none dark:text-gray-400 dark:hover:text-gray-100"
-                >
+                <button @click="open = !open" class="text-sm text-gray-600 hover:text-gray-900 focus:outline-none dark:text-gray-400 dark:hover:text-gray-100">
                     {{ __('Details') }}
                     <span x-show="!open">
                         @svg('hugeicons-arrow-down-01', ['class' => 'inline h-4 w-4 text-gray-900 dark:text-gray-50'])
@@ -127,69 +104,78 @@
                 </div>
             </div>
 
-            <!-- Actions - Always visible, but reorganized for responsive view -->
-            <div class="mt-3 flex flex-wrap justify-start space-x-2">
+            <!-- Actions - Grouped as Action Menu -->
+            <div class="mt-3 flex flex-wrap items-center space-x-2">
+                <!-- Primary Actions - Always visible -->
                 <livewire:backup-tasks.buttons.run-task-button
                     :$backupTask
                     :wire:key="'run-task-button-' . $backupTask->id"
                 />
-
-                <x-secondary-button
-                    x-data=""
-                    x-on:click.prevent="$dispatch('open-modal', 'backup-task-{{ $backupTask->id }}')"
-                    class="!p-2"
-                    :disabled="!$backupTask->logs()->exists()"
-                    :title="$backupTask->logs()->exists() ? __('Click to view this log') : __('No log available')"
-                >
-                    @svg('hugeicons-license', 'h-4 w-4')
-                    <span class="sr-only">{{ __('View Log') }}</span>
-                </x-secondary-button>
 
                 <livewire:backup-tasks.buttons.toggle-pause-button
                     :backupTask="$backupTask"
                     :wire:key="'toggle-pause-button-' . $backupTask->id"
                 />
 
-                <livewire:backup-tasks.buttons.toggle-favourite-button
-                    :backupTask="$backupTask"
-                    :wire:key="'toggle-favourite-button-' . $backupTask->id"
-                />
-
-                <a href="{{ route('backup-tasks.edit', $backupTask) }}" wire:navigate>
-                    <x-secondary-button class="!p-2">
-                        <span class="sr-only">
-                            {{ __('Update Backup Task') }}
-                        </span>
-                        <x-hugeicons-task-edit-01 class="h-4 w-4" />
+                <!-- Secondary Actions - Dropdown -->
+                <div x-data="{ open: false }" class="relative">
+                    <x-secondary-button @click="open = !open" class="!p-2">
+                        @svg('hugeicons-more-vertical-circle-01', 'h-4 w-4')
+                        <span class="sr-only">{{ __('More Actions') }}</span>
                     </x-secondary-button>
-                </a>
+
+                    <div x-show="open" @click.away="open = false" class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700">
+                        <!-- View Log -->
+                        <button
+                            x-data=""
+                            x-on:click.prevent="$dispatch('open-modal', 'backup-task-{{ $backupTask->id }}'); open = false"
+                            class="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-200 dark:hover:bg-gray-600"
+                            :disabled="!$backupTask->logs()->exists()"
+                        >
+                            @svg('hugeicons-license', 'mr-2 h-4 w-4')
+                            {{ __('View Log') }}
+                        </button>
+
+                        <!-- View Webhook URL -->
+                        <button
+                            x-data=""
+                            x-on:click.prevent="$dispatch('open-modal', 'webhook-modal-{{ $backupTask->id }}'); open = false"
+                            class="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-600"
+                        >
+                            @svg('hugeicons-link-03', 'mr-2 h-4 w-4')
+                            {{ __('Webhook URL') }}
+                        </button>
+
+                        <!-- Edit -->
+                        <a
+                            href="{{ route('backup-tasks.edit', $backupTask) }}"
+                            wire:navigate
+                            class="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-600"
+                        >
+                            @svg('hugeicons-task-edit-01', 'mr-2 h-4 w-4')
+                            {{ __('Edit Task') }}
+                        </a>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <!-- Large View (Grid) -->
-        <div class="hidden grid-cols-12 items-center gap-4 md:grid">
+        <!-- Desktop View (Grid) -->
+        <div class="hidden md:grid grid-cols-12 items-center gap-4">
             <!-- Task Type and Label -->
-            <div class="col-span-12 flex items-center space-x-3 md:col-span-3">
+            <div class="col-span-3 flex items-center space-x-3">
                 <div class="flex-shrink-0">
                     @if ($backupTask->isFilesType())
                         <div class="group relative" title="{{ __('Files Task') }}">
-                            <div
-                                class="absolute inset-0 rotate-3 transform rounded-lg bg-gradient-to-br from-purple-300 to-purple-400 transition-all duration-300 group-hover:rotate-6 group-hover:scale-105 dark:from-purple-600 dark:to-purple-700"
-                            ></div>
-                            <div
-                                class="relative rounded-lg bg-white p-2 shadow-sm transition-all duration-300 group-hover:shadow-md dark:bg-gray-800"
-                            >
+                            <div class="absolute inset-0 rotate-3 transform rounded-lg bg-gradient-to-br from-purple-300 to-purple-400 transition-all duration-300 group-hover:rotate-6 group-hover:scale-105 dark:from-purple-600 dark:to-purple-700"></div>
+                            <div class="relative rounded-lg bg-white p-2 shadow-sm transition-all duration-300 group-hover:shadow-md dark:bg-gray-800">
                                 @svg('hugeicons-file-01', 'h-5 w-5 text-purple-600 dark:text-purple-400')
                             </div>
                         </div>
                     @elseif ($backupTask->isDatabaseType())
                         <div class="group relative" title="{{ __('Database Task') }}">
-                            <div
-                                class="absolute inset-0 rotate-3 transform rounded-lg bg-gradient-to-br from-cyan-300 to-cyan-400 transition-all duration-300 group-hover:rotate-6 group-hover:scale-105 dark:from-cyan-600 dark:to-cyan-700"
-                            ></div>
-                            <div
-                                class="relative rounded-lg bg-white p-2 shadow-sm transition-all duration-300 group-hover:shadow-md dark:bg-gray-800"
-                            >
+                            <div class="absolute inset-0 rotate-3 transform rounded-lg bg-gradient-to-br from-cyan-300 to-cyan-400 transition-all duration-300 group-hover:rotate-6 group-hover:scale-105 dark:from-cyan-600 dark:to-cyan-700"></div>
+                            <div class="relative rounded-lg bg-white p-2 shadow-sm transition-all duration-300 group-hover:shadow-md dark:bg-gray-800">
                                 @svg('hugeicons-database', 'h-5 w-5 text-cyan-600 dark:text-cyan-400')
                             </div>
                         </div>
@@ -201,22 +187,14 @@
                     </h3>
                     <div class="ms-1.5 mt-1.5 flex space-x-2">
                         @if ($backupTask->tags()->exists())
-                            <button
-                                x-data=""
-                                x-on:click.prevent="$dispatch('open-modal', 'view-tags-{{ $backupTask->id }}')"
-                                class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                            >
+                            <button x-data="" x-on:click.prevent="$dispatch('open-modal', 'view-tags-{{ $backupTask->id }}')" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
                                 @svg('hugeicons-tags', 'mr-1 h-3 w-3 text-gray-500 dark:text-gray-400')
                                 {{ $backupTask->tags->count() }}
                             </button>
                         @endif
 
                         @if ($backupTask->notificationStreams()->exists())
-                            <button
-                                x-data=""
-                                x-on:click.prevent="$dispatch('open-modal', 'view-notification-streams-{{ $backupTask->id }}')"
-                                class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                            >
+                            <button x-data="" x-on:click.prevent="$dispatch('open-modal', 'view-notification-streams-{{ $backupTask->id }}')" class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
                                 @svg('hugeicons-notification-02', 'mr-1 h-3 w-3 text-gray-500 dark:text-gray-400')
                                 {{ $backupTask->notificationStreams->count() }}
                             </button>
@@ -226,7 +204,7 @@
             </div>
 
             <!-- Server and Destination -->
-            <div class="col-span-12 text-sm md:col-span-3">
+            <div class="col-span-3 text-sm">
                 <p class="text-gray-600 dark:text-gray-300">
                     {{ $backupTask->remoteServer->label }}
                 </p>
@@ -237,18 +215,14 @@
             </div>
 
             <!-- Status -->
-            <div class="col-span-6 text-sm font-medium md:col-span-2">
+            <div class="col-span-2 text-sm font-medium">
                 @if ($backupTask->isPaused())
-                    <span
-                        class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-800 dark:text-red-100"
-                    >
+                    <span class="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-800 dark:text-red-100">
                         @svg('hugeicons-pause', 'mr-1 h-3.5 w-3.5')
                         {{ __('Paused') }}
                     </span>
                 @else
-                    <span
-                        class="{{ $backupTask->status === 'ready' ? 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100' : 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100' }} inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium"
-                    >
+                    <span class="{{ $backupTask->status === 'ready' ? 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100' : 'bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100' }} inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium">
                         @if ($backupTask->status === 'ready')
                             @svg('hugeicons-checkmark-circle-02', 'mr-1 h-3.5 w-3.5')
                         @else
@@ -260,7 +234,7 @@
             </div>
 
             <!-- Schedule -->
-            <div class="col-span-6 text-xs text-gray-500 md:col-span-2 dark:text-gray-400">
+            <div class="col-span-2 text-xs text-gray-500 dark:text-gray-400">
                 <p>
                     <span class="font-medium text-gray-700 dark:text-gray-300">{{ __('Scheduled') }}:</span>
                     @if ($backupTask->isPaused())
@@ -281,33 +255,13 @@
                 </p>
             </div>
 
-            <!-- Actions -->
-            <div class="col-span-12 flex justify-end space-x-2 md:col-span-2">
+            <!-- Actions - Compact Action Bar -->
+            <div class="col-span-2 flex items-center justify-end space-x-2">
+                <!-- Primary Actions -->
                 <livewire:backup-tasks.buttons.run-task-button
                     :$backupTask
                     :wire:key="'run-task-button-large-' . $backupTask->id"
                 />
-
-                <x-secondary-button
-                    x-data=""
-                    x-on:click.prevent="$dispatch('open-modal', 'backup-task-{{ $backupTask->id }}')"
-                    class="!p-2"
-                    :disabled="!$backupTask->logs()->exists()"
-                    :title="$backupTask->logs()->exists() ? __('Click to view this log') : __('No log available')"
-                >
-                    @svg('hugeicons-license', 'h-4 w-4')
-                    <span class="sr-only">{{ __('View Log') }}</span>
-                </x-secondary-button>
-
-                <x-secondary-button
-                    x-data=""
-                    x-on:click.prevent="$dispatch('open-modal', 'webhook-modal-{{ $backupTask->id }}')"
-                    class="!p-2"
-                    :title="__('Click to view this webhook url')"
-                >
-                    @svg('hugeicons-link-03', 'h-4 w-4')
-                    <span class="sr-only">{{ __('View Webhook URL') }}</span>
-                </x-secondary-button>
 
                 <livewire:backup-tasks.buttons.toggle-pause-button
                     :backupTask="$backupTask"
@@ -319,14 +273,46 @@
                     :wire:key="'toggle-favourite-button-large-' . $backupTask->id"
                 />
 
-                <a href="{{ route('backup-tasks.edit', $backupTask) }}" wire:navigate>
-                    <x-secondary-button class="!p-2">
-                        <span class="sr-only">
-                            {{ __('Update Backup Task') }}
-                        </span>
-                        <x-hugeicons-task-edit-01 class="h-4 w-4" />
+                <!-- Secondary Actions Dropdown -->
+                <div x-data="{ open: false }" class="relative">
+                    <x-secondary-button @click="open = !open" class="!p-2">
+                        @svg('hugeicons-more-vertical-circle-01', 'h-4 w-4')
+                        <span class="sr-only">{{ __('More Actions') }}</span>
                     </x-secondary-button>
-                </a>
+
+                    <div style="position: absolute; z-index: 9999;"  x-show="open" @click.away="open = false" class="absolute right-0 z-[100] mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700">
+                        <!-- View Log -->
+                        <button
+                            x-data=""
+                            x-on:click.prevent="$dispatch('open-modal', 'backup-task-{{ $backupTask->id }}'); open = false"
+                            class="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-200 dark:hover:bg-gray-600"
+                            :disabled="!$backupTask->logs()->exists()"
+                        >
+                            @svg('hugeicons-license', 'mr-2 h-4 w-4')
+                            {{ __('View Log') }}
+                        </button>
+
+                        <!-- View Webhook URL -->
+                        <button
+                            x-data=""
+                            x-on:click.prevent="$dispatch('open-modal', 'webhook-modal-{{ $backupTask->id }}'); open = false"
+                            class="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-600"
+                        >
+                            @svg('hugeicons-link-03', 'mr-2 h-4 w-4')
+                            {{ __('Webhook URL') }}
+                        </button>
+
+                        <!-- Edit -->
+                        <a
+                            href="{{ route('backup-tasks.edit', $backupTask) }}"
+                            wire:navigate
+                            class="flex w-full items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-600"
+                        >
+                            @svg('hugeicons-task-edit-01', 'mr-2 h-4 w-4')
+                            {{ __('Edit Task') }}
+                        </a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Pull Request

## Description

This has been an issue for a long time, the buttons would overlap and it looked pretty messy. This resolves it by putting them into a dropdown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce any new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have used translation helpers and provided translations (where appropriate)