### PR TITLE
fix: calculate backup file sizes correctly

### DIFF
--- a/app/Http/Controllers/Admin/InstanceDetailsController.php
+++ b/app/Http/Controllers/Admin/InstanceDetailsController.php
@@ -60,9 +60,9 @@ class InstanceDetailsController extends Controller
      */
     private function isHorizonRunning(): bool
     {
-        $result = Process::run('ps aux | grep "artisan horizon" | grep -v grep');
+        $processResult = Process::run('ps aux | grep "artisan horizon" | grep -v grep');
 
-        return $result->successful() && ! empty($result->output());
+        return $processResult->successful() && ! empty($processResult->output());
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## Description

I noticed we were calculating the database file size poorly, addressed it and re-factored into a method.


## Type of change (Please select one)
- [x] Bug fix
- [ ] New feature
- [ ] Code refactoring
- [ ] UI/UX improvement
- [ ] Performance improvement
- [ ] Language/translation changes
- [ ] Package updates (Composer/npm)
- [ ] Configuration changes
- [ ] Database schema changes
- [ ] Security fix
- [ ] Breaking change

## Testing (Check all that apply)
- [x] Added tests
- [x] Manually tested in local environment

## Checklist (Check all applicable items)
- [x] Self-reviewed code and added necessary tests
- [x] Used translation helpers where appropriate
- [x] Followed [project coding standards](https://docs.vanguardbackup.com/development-handbook#_4-code-quality-and-standards)

## Screenshots (if applicable)

## Additional context (if needed)
